### PR TITLE
setup_requires enum34.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,5 +36,7 @@ setup(
         "flake8",
         # For the astropy.time module
         "astropy",
+        # For the enum module in Python 2
+        "enum34",
     ],
 )


### PR DESCRIPTION
Required by lsstx.DateTime. Note we require enum34 (not just enum) for the
unique() function.

Note that this makes it possible to run `setup.py test` without installing; see discussion on HipChat passim.
